### PR TITLE
fix docs deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,12 +6,11 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
-    repo="https://github.com/juliageometry/Delaunator.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/JuliaGeometry/Delaunator.jl/blob/{commit}{path}#L{line}",
     sitename="Delaunator.jl",
     authors="David Gleich, Steve Kelly",
-    assets=String[],
 )
 
 deploydocs(;
-    repo="github.com/juliageometry/Delaunator.jl",
+    repo="github.com/JuliaGeometry/Delaunator.jl",
 )


### PR DESCRIPTION
the URL is case sensitive in Documenter.jl, even though GitHub itself is not