### PR TITLE
Add Compat entries for extras

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,13 @@ authors = ["David Gleich", "Steve Kelly"]
 version = "0.1.1"
 
 [compat]
+Aqua = "0.8"
+GeometryBasics = "0.4"
+JET = "0.7, 0.8"
+JSON = "0.21"
+StableRNGs = "1"
+Test = "1"
+Pkg = "1"
 julia = "1"
 
 [extras]
@@ -11,8 +18,9 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "GeometryBasics", "JET", "JSON", "Test", "StableRNGs"]
+test = ["Aqua", "GeometryBasics", "JET", "JSON", "Pkg", "Test", "StableRNGs"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Delaunator
+using Pkg
 using Test
 using JSON, GeometryBasics
 
@@ -341,8 +342,17 @@ end
 end 
 
 import Aqua
-Aqua.test_all(Delaunator)
+@testset "Aqua tests" begin 
+    Aqua.test_all(Delaunator)
+end
 
-import JET
-JET.report_package(Delaunator)
+if VERSION >= v"1.8"
+    @testset "JET tests" begin
+        import JET
+        projectinfo = Pkg.project()
+        deps = Pkg.dependencies()
+        @assert deps[projectinfo.dependencies["JET"]].version >= v"0.7.0"
+        JET.report_package(Delaunator)
+    end
+end
 


### PR DESCRIPTION
Fix the non-passing quality tests with Aqua by adding the necessary compat entries to Project.toml as suggested [here](
https://discourse.julialang.org/t/compat-bounds-for-extras/52819).

For most cases, the requested version can be the latest version major version (they are compatible with julia 1.6 or less).
JET compat is a bit more tricky as it supports only limited versions and older JET versions might not work with the newest versions of Julia. I used a trick similar to what was proposed [here](https://github.com/aviatesk/JET.jl/issues/546) to ensure the tests run against version 1.8 and locally for newer versions. Alternatively, the library could support more majour versions of JET.

I added a testset around Aqua and JET so all tests will run even if Aqua fails.