### PR TITLE
Update DelaunayTriangulation.jl description

### DIFF
--- a/README.jmd
+++ b/README.jmd
@@ -148,9 +148,8 @@ of floating point computations.
 - There is limited support for dual cells / Voronoi cells in `VoronoiDelaunay` and 
 a good deal of this functionality is provided by the package `VoronoiCells.jl`. 
 - The `DelaunayTriangulation.jl` package that 
-uses [`ExactPredicates.jl`](https://github.com/lairez/ExactPredicates.jl) to implement various 
-computational geometry tests. This package is under active development and implements a number 
-useful constrained Delaunay triangulations. 
+uses [`AdaptivePredicates.jl`](https://github.com/vchuravy/AdaptivePredicates.jl) and [`ExactPredicates.jl`](https://github.com/lairez/ExactPredicates.jl) to implement various 
+computational geometry tests. This package is under active development and implements a number of methods for unconstrained and constrained Delaunay triangulations and Voronoi tessellations.
 
 In comparison, the `Delaunator.jl` package seeks to mirror the javascript d3-delaunay codes that give good
 enough triangulations for many pixel-level graphics applications and are fast for 2d problems, rather than those that 

--- a/README.jmd
+++ b/README.jmd
@@ -134,7 +134,7 @@ There are a variety of other Delaunay and Voronoi packages in the Julia ecosyste
 
 - [`VoronoiDelaunay.jl`](https://github.com/JuliaGeometry/VoronoiDelaunay.jl)
 - [`VoronoiCells.jl`](https://github.com/JuliaGeometry/VoronoiCells.jl)
-- [`DelaunayTriangulation.jl`](https://github.com/DanielVandH/DelaunayTriangulation.jl)
+- [`DelaunayTriangulation.jl`](https://github.com/JuliaGeometry/DelaunayTriangulation.jl)
 - [`MiniQhull.jl`](https://github.com/gridap/MiniQhull.jl)
 - [`DirectQhull.jl`](https://github.com/JuhaHeiskala/DirectQhull.jl)
 

--- a/README.jmd
+++ b/README.jmd
@@ -148,7 +148,7 @@ of floating point computations.
 - There is limited support for dual cells / Voronoi cells in `VoronoiDelaunay` and 
 a good deal of this functionality is provided by the package `VoronoiCells.jl`. 
 - The `DelaunayTriangulation.jl` package that 
-uses [`AdaptivePredicates.jl`](https://github.com/vchuravy/AdaptivePredicates.jl) and [`ExactPredicates.jl`](https://github.com/lairez/ExactPredicates.jl) to implement various 
+uses [`AdaptivePredicates.jl`](https://github.com/JuliaGeometry/AdaptivePredicates.jl) and [`ExactPredicates.jl`](https://github.com/lairez/ExactPredicates.jl) to implement various 
 computational geometry tests. This package is under active development and implements a number of methods for unconstrained and constrained Delaunay triangulations and Voronoi tessellations.
 
 In comparison, the `Delaunator.jl` package seeks to mirror the javascript d3-delaunay codes that give good

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ There are a variety of other Delaunay and Voronoi packages in the Julia ecosyste
 
 - [`VoronoiDelaunay.jl`](https://github.com/JuliaGeometry/VoronoiDelaunay.jl)
 - [`VoronoiCells.jl`](https://github.com/JuliaGeometry/VoronoiCells.jl)
-- [`DelaunayTriangulation.jl`](https://github.com/DanielVandH/DelaunayTriangulation.jl)
+- [`DelaunayTriangulation.jl`](https://github.com/JuliaGeometry/DelaunayTriangulation.jl)
 - [`MiniQhull.jl`](https://github.com/gridap/MiniQhull.jl)
 - [`DirectQhull.jl`](https://github.com/JuhaHeiskala/DirectQhull.jl)
 
@@ -196,9 +196,8 @@ of floating point computations.
 - There is limited support for dual cells / Voronoi cells in `VoronoiDelaunay` and 
 a good deal of this functionality is provided by the package `VoronoiCells.jl`. 
 - The `DelaunayTriangulation.jl` package that 
-uses [`ExactPredicates.jl`](https://github.com/lairez/ExactPredicates.jl) to implement various 
-computational geometry tests. This package is under active development and implements a number 
-useful constrained Delaunay triangulations. 
+uses [`AdaptivePredicates.jl`](https://github.com/JuliaGeometry/AdaptivePredicates.jl) and [`ExactPredicates.jl`](https://github.com/lairez/ExactPredicates.jl) to implement various 
+computational geometry tests. This package is under active development and implements a number of methods for unconstrained and constrained Delaunay triangulations and Voronoi tessellations.
 
 In comparison, the `Delaunator.jl` package seeks to mirror the javascript d3-delaunay codes that give good
 enough triangulations for many pixel-level graphics applications and are fast for 2d problems, rather than those that 


### PR DESCRIPTION
As of v1.1.0, DelaunayTriangulation.jl's new default is no longer ExactPredicates.jl and is now AdaptivePredicates.jl. I've left both in since they can ExactPredicates.jl is still available through `ExactKernel()`. I also changed the sentence a bit since it's also got a lot to do with Voronoi tessellations instead of only CDTs.