### PR TITLE
Fix incircle issuees

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Delaunator"
 uuid = "466f8f70-d5e3-4806-ac0b-a54b75a91218"
 authors = ["David Gleich", "Steve Kelly"]
-version = "0.1.2"
+version = "0.1.3"
 
 [compat]
 julia = "1.6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -309,6 +309,12 @@ end
     validate(pts[1:100],skip_dualcell=true)
 end
 
+@testset "Issue #20" begin
+    import AdaptivePredicates
+    (pa, pb, pc, pd) = ((-2.1805754507765765e45, -9.077393688127387e59), (5.60747804973906e23, 9.578697981336844e8), (-2.407029693684877e-15, -2.2237653047058956e23), (6.899627924251412e-14, 3.4680080890995206e58))
+    @test AdaptivePredicates.incircle(pa, pb, pc, pd) == Delaunator.incircle(pa, pb, pc, pd)
+end
+
 
 # test('issue #11', (t) => {
 #     validate(t, [[516, 661], [369, 793], [426, 539], [273, 525], [204, 694], [747, 750], [454, 390]]);


### PR DESCRIPTION
Fixes #20. I didn't change the `incircle` method to the one I implemented at https://github.com/JuliaGeometry/AdaptivePredicates.jl/pull/21 but I fixed the conditions for allocating (see the issue). I also fixed the `inbounds` issues by porting over the new versions of the arithmetic functions I implemented at AdaptivePredicates.jl. The `safe_getindex` is necessary unfortunately, even early into the function.

https://github.com/JuliaGeometry/AdaptivePredicates.jl/pull/21 gives some benchmarks with this approach to show that the speed is still good.